### PR TITLE
feat: add cookie-based authentication support for HTML requests

### DIFF
--- a/frontend/src/shared/hooks/useAuth.ts
+++ b/frontend/src/shared/hooks/useAuth.ts
@@ -27,6 +27,11 @@ export function useAuth() {
     }
 
     try {
+      // Definir cookie para requisições HTML (fazer silenciosamente, não bloquear se falhar)
+      api.setCookie(firebaseToken).catch(err => {
+        console.warn('Erro ao definir cookie (não crítico):', err)
+      })
+      
       // Usar o token do Firebase para autenticar no backend
       const response = await api.isSignedIn(firebaseToken)
       
@@ -157,6 +162,12 @@ export function useAuth() {
     // Sincronizar com backend usando token do Firebase
     const backendUser = await syncUserFromBackend()
     
+    // Definir cookie para requisições HTML
+    const firebaseToken = await firebaseAuth.getIdToken()
+    if (firebaseToken) {
+      await api.setCookie(firebaseToken)
+    }
+    
     if (backendUser) {
       setUser(backendUser)
       setIsAuthenticated(true)
@@ -183,6 +194,8 @@ export function useAuth() {
   const logout = useCallback(async () => {
     try {
       await firebaseAuth.signOut()
+      // Limpar cookie no backend
+      await api.clearCookie()
     } catch (error) {
       console.error('Erro ao fazer logout:', error)
     } finally {


### PR DESCRIPTION
- Add setCookie method to ApiService to store Firebase token in cookie
- Add clearCookie method to remove authentication cookie on logout
- Update useAuth hook to automatically set cookie after login
- Update logout to clear authentication cookie
- Enable seamless authentication for both API and HTML requests