### PR TITLE
feat: add order history for clients and owners

### DIFF
--- a/backend/app/controllers/api/v1/order_history_controller.rb
+++ b/backend/app/controllers/api/v1/order_history_controller.rb
@@ -1,0 +1,189 @@
+module Api
+  module V1
+    class OrderHistoryController < ApplicationController
+      include AuthenticableApi
+
+      before_action :authenticate_api_user!
+      skip_before_action :verify_authenticity_token
+      skip_before_action :create_current_order
+      skip_before_action :set_active_storage_url_options
+      before_action :skip_session
+
+      # GET /api/v1/orders/history
+      def index
+        # Se o usuário é owner, retorna pedidos do estabelecimento
+        # Se não, retorna apenas os pedidos do próprio usuário
+        if current_api_user.owner? && current_api_user.establishment.present?
+          # Owner: todos os pedidos do estabelecimento
+          orders = current_api_user.establishment.orders.includes(:establishment, :order_menu_items, :user)
+        else
+          # Cliente: apenas seus próprios pedidos
+          orders = current_api_user.orders.includes(:establishment, :order_menu_items)
+        end
+        
+        # Filtro por status
+        if params[:status].present?
+          orders = orders.where(status: params[:status])
+        end
+        
+        # Filtro por data inicial
+        if params[:start_date].present?
+          start_date = Date.parse(params[:start_date])
+          orders = orders.where('created_at >= ?', start_date.beginning_of_day)
+        end
+        
+        # Filtro por data final
+        if params[:end_date].present?
+          end_date = Date.parse(params[:end_date])
+          orders = orders.where('created_at <= ?', end_date.end_of_day)
+        end
+        
+        # Ordena por data mais recente primeiro
+        orders = orders.order(created_at: :desc)
+        
+        # Conta total antes da paginação
+        total_count = orders.count
+        
+        # Paginação (opcional)
+        page = params[:page]&.to_i || 1
+        per_page = params[:per_page]&.to_i || 20
+        orders = orders.limit(per_page).offset((page - 1) * per_page)
+        
+        render json: {
+          orders: orders.map { |order| format_order(order) },
+          pagination: {
+            page: page,
+            per_page: per_page,
+            total: total_count,
+            total_pages: (total_count.to_f / per_page).ceil
+          }
+        }, status: :ok
+      rescue Date::Error => e
+        render json: {
+          error: 'Data inválida',
+          message: 'Formato de data inválido. Use YYYY-MM-DD'
+        }, status: :bad_request
+      rescue => e
+        Rails.logger.error "[OrderHistoryController] Erro: #{e.class} - #{e.message}"
+        Rails.logger.error e.backtrace.join("\n")
+        render json: {
+          error: 'Erro ao buscar histórico de pedidos',
+          message: e.message
+        }, status: :internal_server_error
+      end
+
+      # GET /api/v1/orders/history/:id
+      def show
+        # Se o usuário é owner, pode ver qualquer pedido do estabelecimento
+        # Se não, apenas seus próprios pedidos
+        if current_api_user.owner? && current_api_user.establishment.present?
+          order = current_api_user.establishment.orders.find_by(id: params[:id])
+        else
+          order = current_api_user.orders.find_by(id: params[:id])
+        end
+        
+        if order
+          render json: {
+            order: format_order(order, include_items: true)
+          }, status: :ok
+        else
+          render json: {
+            error: 'Pedido não encontrado'
+          }, status: :not_found
+        end
+      rescue => e
+        Rails.logger.error "[OrderHistoryController] Erro: #{e.class} - #{e.message}"
+        render json: {
+          error: 'Erro ao buscar pedido',
+          message: e.message
+        }, status: :internal_server_error
+      end
+
+      private
+
+      def skip_session
+        request.session_options[:skip] = true if request.session_options
+      rescue => e
+        Rails.logger.warn "Erro ao pular sessão: #{e.message}"
+      end
+
+      def format_order(order, include_items: false)
+        order_data = {
+          id: order.id,
+          code: order.code,
+          status: order.status,
+          total_price: order.total_price.to_f,
+          created_at: order.created_at.iso8601,
+          updated_at: order.updated_at.iso8601,
+          establishment: {
+            id: order.establishment.id,
+            code: order.establishment.code,
+            name: order.establishment.name
+          }
+        }
+        
+        # Adiciona informações do cliente se disponível
+        if order.user.present?
+          order_data[:customer] = {
+            id: order.user.id,
+            name: order.user.name,
+            email: order.user.email
+          }
+        elsif order.customer_name.present?
+          order_data[:customer] = {
+            name: order.customer_name,
+            email: order.customer_email,
+            phone: order.customer_phone
+          }
+        end
+
+        if include_items && order.order_menu_items.any?
+          order_data[:order_menu_items] = order.order_menu_items.map do |item|
+            format_order_item(item)
+          end
+        end
+
+        order_data
+      end
+
+      def format_order_item(item)
+        item_data = {
+          id: item.id,
+          quantity: item.quantity
+        }
+
+        if item.menu_id
+          menu = Menu.find_by(id: item.menu_id)
+          item_data[:menu] = menu ? {
+            id: menu.id,
+            name: menu.name,
+            price: menu.price.to_f
+          } : nil
+        end
+
+        if item.menu_item_id
+          menu_item = MenuItem.includes(:dish, :drink).find_by(id: item.menu_item_id)
+          if menu_item
+            item_data[:menu_item] = {
+              id: menu_item.id,
+              name: menu_item.dish&.name || menu_item.drink&.name || "Item ##{menu_item.id}"
+            }
+          end
+        end
+
+        if item.portion_id
+          portion = Portion.find_by(id: item.portion_id)
+          if portion
+            item_data[:portion] = {
+              id: portion.id,
+              description: portion.description,
+              price: portion.price.to_f
+            }
+          end
+        end
+
+        item_data
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/orders_controller.rb
+++ b/backend/app/controllers/api/v1/orders_controller.rb
@@ -12,6 +12,8 @@ module Api
         order_data = order_params
         @order = @establishment.orders.new(order_data)
         @order.status = 'draft'
+        # Associa o pedido ao usuário autenticado
+        @order.user = current_api_user if current_api_user
 
         if @order.save
           render json: {

--- a/backend/app/models/order.rb
+++ b/backend/app/models/order.rb
@@ -4,6 +4,7 @@ class Order < ApplicationRecord
   include OrderBroadcastable
 
   belongs_to :establishment
+  belongs_to :user, optional: true
   has_many :order_menu_items, dependent: :destroy
   has_many :menu_items, through: :order_menu_items
   

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
          :rememberable, :validatable
 
   has_one :establishment, dependent: :destroy
+  has_many :orders, dependent: :nullify
 
   validates :name, :email, :last_name, :cpf, presence: true
   validates :cpf, uniqueness: true, format: { with: /\A\d{3}\.\d{3}\.\d{3}-\d{2}\z/ }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -80,6 +80,10 @@ Rails.application.routes.draw do
       post '/sign_in', to: 'sessions#create'
       delete '/sign_out', to: 'sessions#destroy'
       get '/is_signed_in', to: 'sessions#is_signed_in?'
+      
+      # Histórico de pedidos do cliente
+      get '/orders/history', to: 'order_history#index'
+      get '/orders/history/:id', to: 'order_history#show'
     end
   end
 end

--- a/backend/db/migrate/20260205131509_add_user_id_to_orders.rb
+++ b/backend/db/migrate/20260205131509_add_user_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddUserIdToOrders < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :orders, :user, null: true, foreign_key: true
+  end
+end

--- a/frontend/src/client/components/BottomNavigation.tsx
+++ b/frontend/src/client/components/BottomNavigation.tsx
@@ -32,6 +32,13 @@ export default function BottomNavigation() {
         <span>Menu</span>
       </Link>
       
+      <Link to="/orders/history" className={`nav-item ${isActive('orders/history') ? 'active' : ''}`}>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M9 5H7C5.89543 5 5 5.89543 5 7V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V7C19 5.89543 18.1046 5 17 5H15M9 5C9 6.10457 9.89543 7 11 7H13C14.1046 7 15 6.10457 15 5M9 5C9 3.89543 9.89543 3 11 3H13C14.1046 3 15 3.89543 15 5M12 12H15M12 16H15M9 12H9.01M9 16H9.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+        <span>Pedidos</span>
+      </Link>
+      
       <Link to="/login" className={`nav-item ${isActive('account') || isActive('login') ? 'active' : ''}`}>
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M20 21V19C20 17.9391 19.5786 16.9217 18.8284 16.1716C18.0783 15.4214 17.0609 15 16 15H8C6.93913 15 5.92172 15.4214 5.17157 16.1716C4.42143 16.9217 4 17.9391 4 19V21M16 7C16 9.20914 14.2091 11 12 11C9.79086 11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>

--- a/frontend/src/client/hooks/useOrderHistory.ts
+++ b/frontend/src/client/hooks/useOrderHistory.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback } from 'react'
+import { api } from '../../shared/services/api'
+import { useApiData } from '../../owner/hooks/Api/useApiData'
+
+export interface OrderHistoryItem {
+  id: number
+  code: string
+  status: string
+  total_price: number
+  created_at: string
+  updated_at: string
+  establishment: {
+    id: number
+    code: string
+    name: string
+  }
+  customer?: {
+    id?: number
+    name?: string
+    email?: string
+    phone?: string
+  }
+  order_menu_items?: Array<{
+    id: number
+    quantity: number
+    menu?: {
+      id: number
+      name: string
+      price: number
+    }
+    menu_item?: {
+      id: number
+      name: string
+    }
+    portion?: {
+      id: number
+      description: string
+      price: number
+    }
+  }>
+}
+
+export interface OrderHistoryFilters {
+  status?: string
+  start_date?: string
+  end_date?: string
+  page?: number
+  per_page?: number
+}
+
+export interface OrderHistoryPagination {
+  page: number
+  per_page: number
+  total: number
+  total_pages: number
+}
+
+export interface UseOrderHistoryReturn {
+  orders: OrderHistoryItem[]
+  pagination: OrderHistoryPagination | null
+  loading: boolean
+  error: string | null
+  filters: OrderHistoryFilters
+  setFilters: (filters: Partial<OrderHistoryFilters>) => void
+  fetchOrders: () => Promise<void>
+  refetch: () => Promise<void>
+}
+
+export function useOrderHistory(initialFilters?: OrderHistoryFilters): UseOrderHistoryReturn {
+  const [orders, setOrders] = useState<OrderHistoryItem[]>([])
+  const [pagination, setPagination] = useState<OrderHistoryPagination | null>(null)
+  const [filters, setFiltersState] = useState<OrderHistoryFilters>({
+    page: 1,
+    per_page: 20,
+    ...initialFilters,
+  })
+
+  const { loading, error, executeRequest, setError, setLoading } = useApiData<{
+    orders: OrderHistoryItem[]
+    pagination: OrderHistoryPagination
+  }>({
+    defaultErrorMessage: 'Erro ao carregar histórico de pedidos',
+    onSuccess: (data) => {
+      setOrders(data.orders || [])
+      setPagination(data.pagination || null)
+    },
+  })
+
+  const fetchOrders = useCallback(async () => {
+    await executeRequest(
+      async () => {
+        const response = await api.getOrderHistory(filters)
+        if (response.data) {
+          return { data: response.data }
+        }
+        return response as { data?: { orders: OrderHistoryItem[]; pagination: OrderHistoryPagination }, error?: string | string[] }
+      },
+      'Erro ao carregar histórico de pedidos.'
+    )
+  }, [filters, executeRequest])
+
+  const setFilters = useCallback((newFilters: Partial<OrderHistoryFilters>) => {
+    setFiltersState((prev) => ({ ...prev, ...newFilters }))
+  }, [])
+
+  const refetch = useCallback(async () => {
+    await fetchOrders()
+  }, [fetchOrders])
+
+  useEffect(() => {
+    fetchOrders()
+  }, [fetchOrders])
+
+  return {
+    orders,
+    pagination,
+    loading,
+    error,
+    filters,
+    setFilters,
+    fetchOrders,
+    refetch,
+  }
+}

--- a/frontend/src/client/pages/OrderHistory.tsx
+++ b/frontend/src/client/pages/OrderHistory.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { useOrderHistory } from '../hooks/useOrderHistory'
+import { useAuth } from '../../shared/hooks/useAuth'
+import Layout from '../../owner/components/Layout/Layout'
+import '../../css/client/OrderHistory.css'
+
+const ORDER_STATUSES = [
+  { value: '', label: 'Todos os status' },
+  { value: 'pending', label: 'Pendente' },
+  { value: 'preparing', label: 'Preparando' },
+  { value: 'ready', label: 'Pronto' },
+  { value: 'delivered', label: 'Entregue' },
+  { value: 'cancelled', label: 'Cancelado' },
+]
+
+export default function OrderHistory() {
+  const { orders, pagination, loading, error, filters, setFilters, refetch } = useOrderHistory()
+  const { isOwner } = useAuth()
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [status, setStatus] = useState('')
+
+  const handleFilterChange = () => {
+    setFilters({
+      status: status || undefined,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+      page: 1, // Reset to first page when filtering
+    })
+  }
+
+  const handlePageChange = (newPage: number) => {
+    setFilters({ page: newPage })
+  }
+
+  const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    }).format(value)
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  const getStatusLabel = (status: string) => {
+    const statusMap: Record<string, string> = {
+      draft: 'Rascunho',
+      pending: 'Pendente',
+      preparing: 'Preparando',
+      ready: 'Pronto',
+      delivered: 'Entregue',
+      cancelled: 'Cancelado',
+    }
+    return statusMap[status] || status
+  }
+
+  const getStatusClass = (status: string) => {
+    const classMap: Record<string, string> = {
+      draft: 'status-draft',
+      pending: 'status-pending',
+      preparing: 'status-preparing',
+      ready: 'status-ready',
+      delivered: 'status-delivered',
+      cancelled: 'status-cancelled',
+    }
+    return classMap[status] || ''
+  }
+
+  const content = (
+    <div className="order-history-container">
+      <div className="order-history-header">
+        <h1>{isOwner ? 'Histórico de Pedidos do Estabelecimento' : 'Histórico de Pedidos'}</h1>
+      </div>
+
+      {/* Filtros */}
+      <div className="order-history-filters">
+        <div className="filter-group">
+          <label htmlFor="status-filter">Status:</label>
+          <select
+            id="status-filter"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            className="filter-select"
+          >
+            {ORDER_STATUSES.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="start-date">Data Inicial:</label>
+          <input
+            id="start-date"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="filter-input"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="end-date">Data Final:</label>
+          <input
+            id="end-date"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="filter-input"
+          />
+        </div>
+
+        <button onClick={handleFilterChange} className="filter-button">
+          Filtrar
+        </button>
+      </div>
+
+      {/* Lista de Pedidos */}
+      {loading && <div className="loading-message">Carregando pedidos...</div>}
+      
+      {error && (
+        <div className="error-message">
+          <p>{error}</p>
+          <button onClick={refetch}>Tentar novamente</button>
+        </div>
+      )}
+
+      {!loading && !error && orders.length === 0 && (
+        <div className="empty-message">
+          <p>Nenhum pedido encontrado.</p>
+        </div>
+      )}
+
+      {!loading && !error && orders.length > 0 && (
+        <>
+          <div className="orders-list">
+            {orders.map((order) => (
+              <div key={order.id} className="order-card">
+                <div className="order-header">
+                  <div className="order-info">
+                    <h3>Pedido #{order.code}</h3>
+                    <p className="establishment-name">{order.establishment.name}</p>
+                    {order.customer && (
+                      <p className="customer-info">
+                        Cliente: {order.customer.name || order.customer.email || 'N/A'}
+                      </p>
+                    )}
+                    <p className="order-date">{formatDate(order.created_at)}</p>
+                  </div>
+                  <div className="order-status">
+                    <span className={`status-badge ${getStatusClass(order.status)}`}>
+                      {getStatusLabel(order.status)}
+                    </span>
+                  </div>
+                </div>
+                <div className="order-footer">
+                  <div className="order-total">
+                    <strong>Total: {formatCurrency(order.total_price)}</strong>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Paginação */}
+          {pagination && pagination.total_pages > 1 && (
+            <div className="pagination">
+              <button
+                onClick={() => handlePageChange(pagination.page - 1)}
+                disabled={pagination.page === 1}
+                className="pagination-button"
+              >
+                Anterior
+              </button>
+              <span className="pagination-info">
+                Página {pagination.page} de {pagination.total_pages}
+              </span>
+              <button
+                onClick={() => handlePageChange(pagination.page + 1)}
+                disabled={pagination.page >= pagination.total_pages}
+                className="pagination-button"
+              >
+                Próxima
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+
+  // Se for owner, usa o Layout do owner, senão renderiza sem layout
+  if (isOwner) {
+    return <Layout>{content}</Layout>
+  }
+
+  return content
+}

--- a/frontend/src/components/AppRoutes.tsx
+++ b/frontend/src/components/AppRoutes.tsx
@@ -4,6 +4,7 @@ import Register from '../shared/components/Register'
 import Home from '../shared/components/Home'
 import Menu from '../client/pages/Menu'
 import RestaurantsList from '../client/pages/RestaurantsList'
+import OrderHistory from '../client/pages/OrderHistory'
 import CreateEstablishment from '../owner/components/Establishment/CreateEstablishment'
 import EditEstablishment from '../owner/components/Establishment/EditEstablishment'
 import Dashboard from '../owner/components/Dashboard/Dashboard'
@@ -37,6 +38,7 @@ export default function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
       <Route path="/restaurants" element={<RestaurantsList />} />
+      <Route path="/orders/history" element={<OrderHistory />} />
       <Route path="/establishments/new" element={<CreateEstablishment />} />
       <Route path="/establishment/:code/edit" element={<EditEstablishment />} />
       <Route path="/orders" element={<Orders />} />

--- a/frontend/src/css/client/OrderHistory.css
+++ b/frontend/src/css/client/OrderHistory.css
@@ -1,0 +1,284 @@
+@import '../shared/variables.css';
+
+.order-history-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-xl);
+  background: var(--color-bg-primary);
+  min-height: calc(100vh - 200px);
+  width: 100%;
+}
+
+.order-history-header {
+  margin-bottom: var(--spacing-xl);
+}
+
+.order-history-header h1 {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+/* Filtros */
+.order-history-filters {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+  padding: var(--spacing-lg);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-lg);
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  flex: 1;
+  min-width: 150px;
+}
+
+.filter-group label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+}
+
+.filter-select,
+.filter-input {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--border-radius-md);
+  background: var(--color-bg-primary);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+  transition: all var(--transition-base);
+}
+
+.filter-select:focus,
+.filter-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(var(--color-primary-rgb), 0.2);
+}
+
+.filter-button {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  height: fit-content;
+}
+
+.filter-button:hover {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.filter-button:active {
+  transform: translateY(0);
+}
+
+/* Lista de Pedidos */
+.orders-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.order-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-lg);
+  transition: all var(--transition-base);
+}
+
+.order-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transform: translateY(-2px);
+  border-color: var(--color-primary);
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--spacing-md);
+}
+
+.order-info h3 {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.establishment-name {
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.order-date {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.customer-info {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: var(--spacing-xs) 0;
+  font-style: italic;
+}
+
+.order-status {
+  display: flex;
+  align-items: center;
+}
+
+.status-badge {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--border-radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+}
+
+.status-draft {
+  background: #6b7280;
+  color: white;
+}
+
+.status-pending {
+  background: #f59e0b;
+  color: white;
+}
+
+.status-preparing {
+  background: #3b82f6;
+  color: white;
+}
+
+.status-ready {
+  background: #10b981;
+  color: white;
+}
+
+.status-delivered {
+  background: #059669;
+  color: white;
+}
+
+.status-cancelled {
+  background: #ef4444;
+  color: white;
+}
+
+.order-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--spacing-md);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.order-total {
+  font-size: var(--font-size-lg);
+  color: var(--text-primary);
+}
+
+/* Mensagens */
+.loading-message,
+.error-message,
+.empty-message {
+  text-align: center;
+  padding: var(--spacing-2xl);
+  color: var(--text-secondary);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.error-message {
+  color: #ef4444;
+}
+
+.error-message button {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: var(--color-primary);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+}
+
+/* Paginação */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-lg);
+}
+
+.pagination-button {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: var(--color-bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  transition: all var(--transition-base);
+}
+
+.pagination-button:hover:not(:disabled) {
+  background: var(--color-primary);
+  color: var(--color-white);
+  border-color: var(--color-primary);
+}
+
+.pagination-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .order-history-container {
+    padding: var(--spacing-md);
+  }
+
+  .order-history-filters {
+    flex-direction: column;
+  }
+
+  .filter-group {
+    width: 100%;
+  }
+
+  .order-header {
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .order-status {
+    align-self: flex-start;
+  }
+}

--- a/frontend/src/owner/components/Layout/Layout.tsx
+++ b/frontend/src/owner/components/Layout/Layout.tsx
@@ -72,10 +72,19 @@ export default function Layout({ children }: LayoutProps) {
                 </Link>
                 <Link
                   to={`/establishment/${establishmentCode}/orders`}
-                  className={`owner-nav-link ${isActive('/orders') ? 'active' : ''}`}
+                  className={`owner-nav-link ${isActive('/orders') && !isActive('/orders/history') ? 'active' : ''}`}
                   title="Pedidos"
                 >
                   <img src={OrdersIcon} alt="Pedidos" className="nav-icon" />
+                </Link>
+                <Link
+                  to="/orders/history"
+                  className={`owner-nav-link ${isActive('/orders/history') ? 'active' : ''}`}
+                  title="Histórico de Pedidos"
+                >
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="nav-icon">
+                    <path d="M9 5H7C5.89543 5 5 5.89543 5 7V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V7C19 5.89543 18.1046 5 17 5H15M9 5C9 6.10457 9.89543 7 11 7H13C14.1046 7 15 6.10457 15 5M9 5C9 3.89543 9.89543 3 11 3H13C14.1046 3 15 3.89543 15 5M12 12H15M12 16H15M9 12H9.01M9 16H9.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
                 </Link>
                 <Link
                   to={`/establishment/${establishmentCode}/working-hours`}


### PR DESCRIPTION
Backend:
- Add user_id to orders table (migration)
- Associate orders with users when created
- Create OrderHistoryController with filters by status and date
- Support for both clients (own orders) and owners (establishment orders)
- Add customer information to order history response

Frontend:
- Create OrderHistory page component with filters
- Add useOrderHistory hook for data fetching
- Add order history API service methods
- Add navigation link for clients (bottom nav) and owners (sidebar)
- Support both client and owner layouts
- Display customer information for owners